### PR TITLE
add origin_consortium to DATS.json

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -97,7 +97,7 @@
 	},
 	{
 		"value": "music"
-    },		
+    },
 	{
 		"value": "intervals"
     }
@@ -171,6 +171,14 @@
             "values": [
                 {
                     "value": "Quebec"
+                }
+            ]
+        },
+{
+            "category": "origin_consortium",
+            "values": [
+                {
+                    "value": "EEGnet"
                 }
             ]
         },


### PR DESCRIPTION
This PR adds the value "EEGnet" to the `origin_consortium` field in DATS.json.